### PR TITLE
add password_use parameter

### DIFF
--- a/model/identities.go
+++ b/model/identities.go
@@ -22,6 +22,7 @@ type Identity struct {
 	MayAccessPop3        bool   `json:"may_access_pop3"`
 	MayAccessManageSieve bool   `json:"may_access_managesieve"`
 	Password             string `json:"password"`
+	PasswordUse          string `json:"password_use"`
 	FooterActive         bool   `json:"footer_active"`
 	FooterPlainBody      string `json:"footer_plain_body"`
 	FooterHtmlBody       string `json:"footer_html_body"`


### PR DESCRIPTION
I got a sneak peak at the new documentation for the identities API:

>   password_use: "none" ->
  Used if you just need to be able to send using a specific "From" identity,
  but still authenticate with the mailbox address and password. Receiving is also
  configured out of the box by an implicit alias, so you can receive replies.
   
>   password_use: "mailbox" ->
  Used if you want an alternative address but linked to the same mailbox using the same password.
  Mailbox password changes are reflected also on the identity. Sending identities are implied and
  receiving is automatically configured, so you don't need extra aliases.
   
>   password_use: "custom" ->
  Used if you need an application specific password (e.g. your phone), shared mailbox with individual
  passwords or sandboxing of accounts for specific services. Sending identities are implied and receiving is
  automatically configured, so you don't need extra aliases.