### PR TITLE
Add rate limiting support to MigaduClient via configurable options

### DIFF
--- a/client/migadu_client.go
+++ b/client/migadu_client.go
@@ -8,6 +8,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"golang.org/x/time/rate"
 	"io"
 	"net/http"
 	"time"
@@ -15,14 +16,36 @@ import (
 
 // MigaduClient holds all necessary information to interact with the Migadu API
 type MigaduClient struct {
-	HTTPClient *http.Client
-	Endpoint   string
-	Username   string
-	Token      string
+	HTTPClient  *http.Client
+	Endpoint    string
+	Username    string
+	Token       string
+	RateLimiter *rate.Limiter
+}
+
+// Option is a functional option for configuring a MigaduClient.
+// Pass one or more options to New to customize client behavior.
+type Option func(*MigaduClient)
+
+// WithRateLimit configures a rate limiter that allows at most rateLimit requests
+// per rateInterval. The limiter blocks each request until a token is available,
+// so callers do not need to implement back-off themselves.
+//
+// Example: WithRateLimit(60, 2*time.Minute) permits 60 requests every 2 minutes.
+func WithRateLimit(rateLimit int, rateInterval time.Duration) Option {
+	return func(c *MigaduClient) {
+		c.RateLimiter = rate.NewLimiter(rate.Every(rateInterval/time.Duration(rateLimit)), rateLimit)
+	}
+}
+
+// WithDefaultRateLimit applies the rate limit recommended by the Migadu API:
+// 60 requests per 2 minutes (~1 request per 2 seconds).
+func WithDefaultRateLimit() Option {
+	return WithRateLimit(60, 2*time.Minute)
 }
 
 // New creates a new MigaduClient
-func New(endpoint, username, token *string, timeout time.Duration) (*MigaduClient, error) {
+func New(endpoint, username, token *string, timeout time.Duration, opts ...Option) (*MigaduClient, error) {
 	if username == nil {
 		return nil, errors.New("no username supplied")
 	}
@@ -41,10 +64,21 @@ func New(endpoint, username, token *string, timeout time.Duration) (*MigaduClien
 		c.Endpoint = *endpoint
 	}
 
+	for _, opt := range opts {
+		opt(&c)
+	}
+
 	return &c, nil
 }
 
 func (c *MigaduClient) doRequest(req *http.Request) ([]byte, error) {
+	if c.RateLimiter != nil {
+		err := c.RateLimiter.Wait(req.Context())
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	req.SetBasicAuth(c.Username, c.Token)
 	req.Header.Add("Content-Type", "application/json")
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@
 
 module github.com/metio/migadu-client.go
 
-go 1.22
+go 1.25.0
 
-require golang.org/x/net v0.35.0
+require (
+	golang.org/x/net v0.35.0
+	golang.org/x/time v0.15.0
+)
 
 require golang.org/x/text v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
 golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=


### PR DESCRIPTION
# Add optional client-side rate limiting support

## Problem

The Migadu API enforces a rate limit of **60 requests per 2 minutes**, but this is not documented anywhere in their public API docs. When the limit is exceeded, the API returns `403 Forbidden` with the message _"Request forbidden by administrative rules"_ — which is indistinguishable from actual authorization errors. This makes it difficult for automation tools to handle rate limiting gracefully.

I encountered this while using [the Terraform provider](https://github.com/metio/terraform-provider-migadu) to manage ~240 identity resources, which triggered the rate limit and resulted in a temporary IP block.

## How I confirmed the rate limit

I contacted Migadu support directly and received the following confirmation:

> "The threshold for the rate limit is 60 requests in 2 minutes."  
> — Migadu Support (Miki)

I have also submitted feedback to Migadu requesting that they return `429 Too Many Requests` with `Retry-After` headers instead of `403`, which would allow clients to implement automatic backoff. Until that change is made, client-side rate limiting is the most reliable way to prevent hitting the limit.

## Changes

- Added `RateLimiter *rate.Limiter` field to `MigaduClient`
- Added `Option` type using the functional options pattern
- Added `WithRateLimit(requests int, interval time.Duration)` to configure custom rate limits
- Added `WithDefaultRateLimit()` convenience option (60 requests / 2 minutes)
- Rate limiter is applied in `doRequest()` before each API call via `limiter.Wait(ctx)`
- New dependency: `golang.org/x/time/rate`

## Design decisions

- **Opt-in by default**: If no `Option` is passed, `RateLimiter` is `nil` and behavior is unchanged — no breaking changes for existing users.
- **Functional options pattern**: Follows idiomatic Go conventions (used by `grpc.Dial`, `zap.New`, etc.) and allows future extensibility without changing the `New()` signature.
- **Context-aware**: `limiter.Wait(ctx)` respects context cancellation, so Terraform can still abort operations cleanly.

## Usage

```go
// No rate limiting (existing behavior, unchanged)
client, err := client.New(endpoint, username, token, timeout)

// With default Migadu rate limit (60 req / 2 min)
client, err := client.New(endpoint, username, token, timeout, client.WithDefaultRateLimit())

// With custom rate limit
client, err := client.New(endpoint, username, token, timeout, client.WithRateLimit(30, 1*time.Minute))
```